### PR TITLE
fixed link to error in slack

### DIFF
--- a/src/LogAnalyticsViewer.Worker/SlackIntegration/SlackIntegrationService.cs
+++ b/src/LogAnalyticsViewer.Worker/SlackIntegration/SlackIntegrationService.cs
@@ -46,7 +46,7 @@ namespace LogAnalyticsViewer.Worker.SlackIntegration
         {
             var link = _settings.EventUrlFormat
                 .Replace("{From}", e.TimeGenerated.ToCommonFormat())
-                .Replace("{To}", e.TimeGenerated.ToCommonFormat())
+                .Replace("{To}", e.TimeGenerated.AddMilliseconds(1).ToCommonFormat())
                 .Replace("{QueryId}", queryId.ToString());
                 
             var text = _settings.MessagePattern


### PR DESCRIPTION
looks like log analytics made some internal changes and query with from === to doesn't work anymore.

So increased to by one ms